### PR TITLE
Paraswap: Allow bot to execute swap fee setter

### DIFF
--- a/tasks/2023020101-paraswap-fee-redistributor/input.arbitrum.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/input.arbitrum.ts
@@ -96,7 +96,7 @@ export default {
     swapFeeSetterActionParams: {
       impl: undefined,
       admin: owner,
-      managers: [mimicAdmin],
+      managers: [mimicAdmin, BOT],
       feeParams: [
         { pct: 0, cap: 0, token: ZERO_ADDRESS, period: 0 },
         { pct: fp(0.005), cap: toUSDC(5000), token: tokens.USDC, period: MONTH }, // 0.5%

--- a/tasks/2023020101-paraswap-fee-redistributor/input.avalanche.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/input.avalanche.ts
@@ -95,7 +95,7 @@ export default {
     swapFeeSetterActionParams: {
       impl: undefined,
       admin: owner,
-      managers: [mimicAdmin],
+      managers: [mimicAdmin, BOT],
       feeParams: [
         { pct: 0, cap: 0, token: ZERO_ADDRESS, period: 0 },
         { pct: fp(0.005), cap: toUSDC(5000), token: tokens.USDC, period: MONTH }, // 0.5%

--- a/tasks/2023020101-paraswap-fee-redistributor/input.bsc.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/input.bsc.ts
@@ -95,7 +95,7 @@ export default {
     swapFeeSetterActionParams: {
       impl: undefined,
       admin: owner,
-      managers: [mimicAdmin],
+      managers: [mimicAdmin, BOT],
       feeParams: [
         { pct: 0, cap: 0, token: ZERO_ADDRESS, period: 0 },
         { pct: fp(0.005), cap: toUSDC(5000), token: tokens.USDC, period: MONTH }, // 0.5%

--- a/tasks/2023020101-paraswap-fee-redistributor/input.fantom.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/input.fantom.ts
@@ -95,7 +95,7 @@ export default {
     swapFeeSetterActionParams: {
       impl: undefined,
       admin: owner,
-      managers: [mimicAdmin],
+      managers: [mimicAdmin, BOT],
       feeParams: [
         { pct: 0, cap: 0, token: ZERO_ADDRESS, period: 0 },
         { pct: fp(0.005), cap: toUSDC(5000), token: tokens.USDC, period: MONTH }, // 0.5%

--- a/tasks/2023020101-paraswap-fee-redistributor/input.mainnet.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/input.mainnet.ts
@@ -92,7 +92,7 @@ export default {
     swapFeeSetterActionParams: {
       impl: undefined,
       admin: owner,
-      managers: [mimicAdmin],
+      managers: [mimicAdmin, BOT],
       feeParams: [
         { pct: 0, cap: 0, token: ZERO_ADDRESS, period: 0 },
         { pct: fp(0.005), cap: toUSDC(5000), token: tokens.USDC, period: MONTH }, // 0.5%

--- a/tasks/2023020101-paraswap-fee-redistributor/input.optimism.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/input.optimism.ts
@@ -96,7 +96,7 @@ export default {
     swapFeeSetterActionParams: {
       impl: undefined,
       admin: owner,
-      managers: [mimicAdmin],
+      managers: [mimicAdmin, BOT],
       feeParams: [
         { pct: 0, cap: 0, token: ZERO_ADDRESS, period: 0 },
         { pct: fp(0.005), cap: toUSDC(5000), token: tokens.USDC, period: MONTH }, // 0.5%

--- a/tasks/2023020101-paraswap-fee-redistributor/input.polygon.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/input.polygon.ts
@@ -96,7 +96,7 @@ export default {
     swapFeeSetterActionParams: {
       impl: undefined,
       admin: owner,
-      managers: [mimicAdmin],
+      managers: [mimicAdmin, BOT],
       feeParams: [
         { pct: 0, cap: 0, token: ZERO_ADDRESS, period: 0 },
         { pct: fp(0.005), cap: toUSDC(5000), token: tokens.USDC, period: MONTH }, // 0.5%

--- a/tasks/2023020101-paraswap-fee-redistributor/test/behavior.arbitrum.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/test/behavior.arbitrum.ts
@@ -262,7 +262,7 @@ export default function itDeploysParaswapFeeRedistributorCorrectly(): void {
         { name: 'nativeClaimer', account: nativeClaimer, roles: [] },
         { name: 'swapFeeSetter', account: swapFeeSetter, roles: [] },
         { name: 'managers', account: managers, roles: ['call'] },
-        { name: 'relayers', account: relayers, roles: [] },
+        { name: 'relayers', account: relayers, roles: ['call'] },
       ])
     })
 

--- a/tasks/2023020101-paraswap-fee-redistributor/test/behavior.avalanche.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/test/behavior.avalanche.ts
@@ -262,7 +262,7 @@ export default function itDeploysParaswapFeeRedistributorCorrectly(): void {
         { name: 'nativeClaimer', account: nativeClaimer, roles: [] },
         { name: 'swapFeeSetter', account: swapFeeSetter, roles: [] },
         { name: 'managers', account: managers, roles: ['call'] },
-        { name: 'relayers', account: relayers, roles: [] },
+        { name: 'relayers', account: relayers, roles: ['call'] },
       ])
     })
 

--- a/tasks/2023020101-paraswap-fee-redistributor/test/behavior.bsc.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/test/behavior.bsc.ts
@@ -264,7 +264,7 @@ export default function itDeploysParaswapFeeRedistributorCorrectly(): void {
         { name: 'nativeClaimer', account: nativeClaimer, roles: [] },
         { name: 'swapFeeSetter', account: swapFeeSetter, roles: [] },
         { name: 'managers', account: managers, roles: ['call'] },
-        { name: 'relayers', account: relayers, roles: [] },
+        { name: 'relayers', account: relayers, roles: ['call'] },
       ])
     })
 

--- a/tasks/2023020101-paraswap-fee-redistributor/test/behavior.fantom.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/test/behavior.fantom.ts
@@ -264,7 +264,7 @@ export default function itDeploysParaswapFeeRedistributorCorrectly(): void {
         { name: 'nativeClaimer', account: nativeClaimer, roles: [] },
         { name: 'swapFeeSetter', account: swapFeeSetter, roles: [] },
         { name: 'managers', account: managers, roles: ['call'] },
-        { name: 'relayers', account: relayers, roles: [] },
+        { name: 'relayers', account: relayers, roles: ['call'] },
       ])
     })
 

--- a/tasks/2023020101-paraswap-fee-redistributor/test/behavior.mainnet.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/test/behavior.mainnet.ts
@@ -261,7 +261,7 @@ export default function itDeploysParaswapFeeRedistributorCorrectly(): void {
         { name: 'nativeClaimer', account: nativeClaimer, roles: [] },
         { name: 'swapFeeSetter', account: swapFeeSetter, roles: [] },
         { name: 'managers', account: managers, roles: ['call'] },
-        { name: 'relayers', account: relayers, roles: [] },
+        { name: 'relayers', account: relayers, roles: ['call'] },
       ])
     })
 

--- a/tasks/2023020101-paraswap-fee-redistributor/test/behavior.optimism.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/test/behavior.optimism.ts
@@ -262,7 +262,7 @@ export default function itDeploysParaswapFeeRedistributorCorrectly(): void {
         { name: 'nativeClaimer', account: nativeClaimer, roles: [] },
         { name: 'swapFeeSetter', account: swapFeeSetter, roles: [] },
         { name: 'managers', account: managers, roles: ['call'] },
-        { name: 'relayers', account: relayers, roles: [] },
+        { name: 'relayers', account: relayers, roles: ['call'] },
       ])
     })
 

--- a/tasks/2023020101-paraswap-fee-redistributor/test/behavior.polygon.ts
+++ b/tasks/2023020101-paraswap-fee-redistributor/test/behavior.polygon.ts
@@ -264,7 +264,7 @@ export default function itDeploysParaswapFeeRedistributorCorrectly(): void {
         { name: 'nativeClaimer', account: nativeClaimer, roles: [] },
         { name: 'swapFeeSetter', account: swapFeeSetter, roles: [] },
         { name: 'managers', account: managers, roles: ['call'] },
-        { name: 'relayers', account: relayers, roles: [] },
+        { name: 'relayers', account: relayers, roles: ['call'] },
       ])
     })
 


### PR DESCRIPTION
This PR only marks the bot as a manager for the `SwapFeeSetter` action as it is no longer a relayed action.